### PR TITLE
Responsive layout calls grid-core with different $gridColumnWidth values...

### DIFF
--- a/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
@@ -505,11 +505,11 @@
 }
 
 // The Grid
-@mixin grid-core-offset($columns) {
+@mixin grid-core-offset($gridColumnWidth, $gridGutterWidth, $columns) {
   margin-left: ($gridColumnWidth * $columns) + ($gridGutterWidth * ($columns - 1)) + ($gridGutterWidth * 2);
 }
 
-@mixin grid-core-span($columns) {
+@mixin grid-core-span($gridColumnWidth, $gridGutterWidth, $columns) {
   width: ($gridColumnWidth * $columns) + ($gridGutterWidth * ($columns - 1));
 }
 
@@ -527,12 +527,12 @@
   // Set the container width, and override it for fixed navbars in media queries
   .container,
   .navbar-fixed-top .container,
-  .navbar-fixed-bottom .container { @include grid-core-span($gridColumns); }
+  .navbar-fixed-bottom .container { @include grid-core-span($gridColumnWidth, $gridGutterWidth, $gridColumns); }
 
   // generate .spanX and .offsetX
   @for $index from 1 through $gridColumns {
-    .span#{$index}  { @include grid-core-span($index) }
-    .offset#{$index} { @include grid-core-offset($index) }
+    .span#{$index}  { @include grid-core-span($gridColumnWidth, $gridGutterWidth, $index) }
+    .offset#{$index} { @include grid-core-offset($gridColumnWidth, $gridGutterWidth, $index) }
   }
 }
 
@@ -559,7 +559,7 @@
   }
 }
 
-@mixin grid-input-span($columns) {
+@mixin grid-input-span($gridColumnWidth, $gridGutterWidth, $columns) {
   width: (($gridColumnWidth) * $columns) + ($gridGutterWidth * ($columns - 1)) - 10;
 }
 @mixin grid-input($gridColumnWidth, $gridGutterWidth) {
@@ -574,7 +574,7 @@
     input.span#{$index},
     textarea.span#{$index},
     .uneditable-input.span#{$index} {
-      @include grid-input-span($index);
+      @include grid-input-span($gridColumnWidth, $gridGutterWidth, $index);
     }
   }
 }


### PR DESCRIPTION
.... grid-core then call grid-core-span which uses the global $gridColumnWidth variable. Thus the responsive layouts do not get the correct span widths.
