### PR TITLE
Fixed issue with incorrect responsive span widths.

### DIFF
--- a/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
@@ -505,11 +505,11 @@
 }
 
 // The Grid
-@mixin grid-core-offset($columns) {
+@mixin grid-core-offset($gridColumnWidth, $gridGutterWidth, $columns) {
   margin-left: ($gridColumnWidth * $columns) + ($gridGutterWidth * ($columns - 1)) + ($gridGutterWidth * 2);
 }
 
-@mixin grid-core-span($columns) {
+@mixin grid-core-span($gridColumnWidth, $gridGutterWidth, $columns) {
   width: ($gridColumnWidth * $columns) + ($gridGutterWidth * ($columns - 1));
 }
 
@@ -527,16 +527,16 @@
   // Set the container width, and override it for fixed navbars in media queries
   .container,
   .navbar-fixed-top .container,
-  .navbar-fixed-bottom .container { @include grid-core-span($gridColumns); }
+  .navbar-fixed-bottom .container { @include grid-core-span($gridColumnWidth, $gridGutterWidth, $gridColumns); }
 
   // generate .spanX and .offsetX
   @for $index from 1 through $gridColumns {
-    .span#{$index}  { @include grid-core-span($index) }
-    .offset#{$index} { @include grid-core-offset($index) }
+    .span#{$index}  { @include grid-core-span($gridColumnWidth, $gridGutterWidth, $index) }
+    .offset#{$index} { @include grid-core-offset($gridColumnWidth, $gridGutterWidth, $index) }
   }
 }
 
-@mixin grid-fluid-span($columns) {
+@mixin grid-fluid-span($gridColumnWidth, $gridGutterWidth, $columns) {
   width: ($fluidGridColumnWidth * $columns) + ($fluidGridGutterWidth * ($columns - 1));
 }
 
@@ -554,12 +554,12 @@
 
     // generate .spanX
     @for $index from 1 through $gridColumns {
-      > .span#{$index} { @include grid-fluid-span($index); }
+      > .span#{$index} { @include grid-fluid-span($gridColumnWidth, $gridGutterWidth, $index); }
     }
   }
 }
 
-@mixin grid-input-span($columns) {
+@mixin grid-input-span($gridColumnWidth, $gridGutterWidth, $columns) {
   width: (($gridColumnWidth) * $columns) + ($gridGutterWidth * ($columns - 1)) - 10;
 }
 @mixin grid-input($gridColumnWidth, $gridGutterWidth) {
@@ -574,7 +574,7 @@
     input.span#{$index},
     textarea.span#{$index},
     .uneditable-input.span#{$index} {
-      @include grid-input-span($index);
+      @include grid-input-span($gridColumnWidth, $gridGutterWidth, $index);
     }
   }
 }

--- a/vendor/assets/stylesheets/twitter/bootstrap/_navbar.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_navbar.scss
@@ -181,7 +181,7 @@
 
 .navbar-fixed-top .container,
 .navbar-fixed-bottom .container {
-  @include grid-core-span($gridColumns);
+  @include grid-core-span($gridColumnWidth, $gridGutterWidth, $gridColumns);
 }
 
 // Fixed to top


### PR DESCRIPTION
responsive.scss makes a few calls to the mixin grid-core with width and gutter values that are different than the global variable setting. grid-core mixin (and several others) call grid-core-span without passing the new width and gutter values. grid-core-span then uses the incorrect global values, resulting in incorrect values for the responsive layout spans. 

Fixed by sending non global $gridColumnWidth and $gridGutterWidth to grid-core-span (and a few other mixins) 
