### PR TITLE
Fixed padding on labels. According to twitter bootstrap values

### DIFF
--- a/vendor/assets/stylesheets/twitter/bootstrap/_labels.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_labels.scss
@@ -3,7 +3,7 @@
 
 // Base
 .label {
-  padding: 11x 4px 3px;
+  padding: 1px 4px 2px;
   font-size: $baseFontSize * .846;
   font-weight: bold;
   line-height: 13px; // ensure proper line-height if floated


### PR DESCRIPTION
padding: 1px 4px 2px is the correct value from twitter bootstrap
