### PR TITLE
remove e function calls

### DIFF
--- a/vendor/assets/stylesheets/twitter/bootstrap/_buttons.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_buttons.scss
@@ -54,7 +54,7 @@
   $shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
   @include box-shadow($shadow);
   background-color: darken($white, 10%);
-  background-color: darken($white, 15%) e("\9");
+  background-color: darken($white, 15%) \9; /* IE6-9 */
   outline: 0;
 }
 

--- a/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
@@ -427,7 +427,7 @@
   // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
   &:active,
   &.active {
-    background-color: darken($endColor, 10%) e("\9");
+    background-color: darken($endColor, 10%) \9; /* IE6-9 */
   }
 }
 

--- a/vendor/assets/stylesheets/twitter/bootstrap/_modals.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_modals.scss
@@ -44,7 +44,7 @@
   @include box-shadow(0 3px 7px rgba(0,0,0,0.3));
   @include background-clip(padding-box);
   &.fade {
-    @include transition(e('opacity .3s linear, top .3s ease-out'));
+    @include transition('opacity .3s linear, top .3s ease-out');
     top: -25%;
   }
   &.fade.in { top: 50%; }


### PR DESCRIPTION
When using bootstrap-sass-rails in conjunction with the latest compass-rails, you get this error from _mixins.scss:

"Sass::SyntaxError: wrong number of arguments (1 or 0) for `e'"

Escaping isn't necessary in Sass, and this function collides with new Compass function which takes no args.

This issue is similar to https://github.com/vwall/compass-twitter-bootstrap/issues/40.
