### PR TITLE
making label color working

### DIFF
--- a/lib/bootstrap/sass/rails/version.rb
+++ b/lib/bootstrap/sass/rails/version.rb
@@ -1,7 +1,7 @@
 module Bootstrap
   module Sass
     module Rails
-      VERSION = '2.0.3.0pre1'
+      VERSION = '2.0.3.0pre2correct'
     end
   end
 end

--- a/vendor/assets/stylesheets/twitter/bootstrap/_labels-badges.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_labels-badges.scss
@@ -35,21 +35,43 @@ a {
 
 // Colors
 // Only give background-color difference to links (and to simplify, we don't qualifty with `a` but [href] attribute)
-.label,
-.badge {
-  // Important (red)
-  &-important        { background-color: $errorText; }
-  &-important:hover  { background-color: darken($errorText, 10%); }
-  // Warnings (orange)
-  &-warning          { background-color: $orange; }
-  &-warning:hover    { background-color: darken($orange, 10%); }
-  // Success (green)
-  &-success          { background-color: $successText; }
-  &-success:hover    { background-color: darken($successText, 10%); }
-  // Info (turquoise)
-  &-info             { background-color: $infoText; }
-  &-info:hover       { background-color: darken($infoText, 10%); }
-  // Inverse (black)
-  &-inverse          { background-color: $grayDark; }
-  &-inverse:hover    { background-color: darken($grayDark, 10%); }
+// Important (red)
+.label-important,
+.badge-important {
+  background-color: $errorText;
+  &:hover {
+    background-color: darken($errorText, 10%);
+  }
+}
+// Warnings (orange)
+.label-warning,
+.badge-warning {
+  background-color: $orange;
+  &:hover {
+    background-color: darken($orange, 10%);
+  }
+}
+// Success (green)
+.label-success,
+.badge-success {
+  background-color: $successText;
+  &:hover {
+    background-color: darken($successText, 10%);
+  }
+}
+// Info (turquoise)
+.label-info,
+.badge-info {
+  background-color: $infoText;
+  &:hover {
+    background-color: darken($infoText, 10%);
+  }
+}
+// Inverse (black)
+.label-inverse,
+.badge-inverse {
+  background-color: $grayDark;
+  &:hover {
+    background-color: darken($grayDark, 10%);
+  }
 }


### PR DESCRIPTION
Hello

The badges and label didn't work since the new version.

Since the new version, the label color are not displayed.
I think that the new system with the &-important ... ... are not a good syntax.
The output asset is : label -important and not label-important

This should fix that 

ps : I'm not sure because i'm new in sass ;)
