### PR TITLE
unquote long arguments passed as string

### DIFF
--- a/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
@@ -202,18 +202,18 @@
 
 // Drop shadows
 @mixin box-shadow($shadow) {
-  -webkit-box-shadow: $shadow;
-     -moz-box-shadow: $shadow;
-          box-shadow: $shadow;
+  -webkit-box-shadow: unquote($shadow);
+     -moz-box-shadow: unquote($shadow);
+          box-shadow: unquote($shadow);
 }
 
 // Transitions
 @mixin transition($transition) {
-  -webkit-transition: $transition;
-     -moz-transition: $transition;
-      -ms-transition: $transition;
-       -o-transition: $transition;
-          transition: $transition;
+  -webkit-transition: unquote($transition);
+     -moz-transition: unquote($transition);
+      -ms-transition: unquote($transition);
+       -o-transition: unquote($transition);
+          transition: unquote($transition);
 }
 
 // Transformations


### PR DESCRIPTION
passing long quoted strings to certain functions, namely transition
and box-shadow results in those arguments being quoted in the
compiled css - which means they won't work - so use the sass
function unquote on these function unconditionally to make
sure that the box-shadow and transition functions always
return something sensible.
