### PR TITLE
add min-height: 1px; to .span* classes to prevent grid columns from collapsing (original fix - https://github.com/twitter/bootstrap/commit/85dcbd0b345378046ae99f6001df1222a75046b2)

### DIFF
--- a/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/twitter/bootstrap/_mixins.scss
@@ -553,6 +553,7 @@
 
   [class*="span"] {
     float: left;
+    min-height: 1px; // prevent collapsing columns
     margin-left: $gridGutterWidth;
   }
 


### PR DESCRIPTION
Fix grid columns collapsing
