### PR TITLE
add twitter bootstrap breadcrumbs support

### DIFF
--- a/app/helpers/twitter_breadcrumbs_helper.rb
+++ b/app/helpers/twitter_breadcrumbs_helper.rb
@@ -1,0 +1,10 @@
+module TwitterBreadcrumbsHelper
+  def render_breadcrumbs(divider = '/', &block)
+    content = render :partial => 'twitter-bootstrap/breadcrumbs', :layout => false, :locals => { :divider => divider }
+    if block_given?
+      capture(content, &block)
+    else
+      content
+    end
+  end
+end

--- a/app/views/twitter-bootstrap/_breadcrumbs.html.erb
+++ b/app/views/twitter-bootstrap/_breadcrumbs.html.erb
@@ -1,0 +1,14 @@
+<% if @breadcrumbs.present? %>
+  <ul class="breadcrumb">
+    <% separator = divider.html_safe %>
+    <% @breadcrumbs[0..-2].each do |crumb| %>
+      <li>
+        <%= link_to crumb[:name], crumb[:url], crumb[:options] %>
+        <span class="divider"><%= separator %></span>
+      </li>
+    <% end %>
+    <li class="active">
+      <%= @breadcrumbs.last[:name] %>
+    </li>
+  </ul>
+<% end %>

--- a/lib/bootstrap/sass/rails/engine.rb
+++ b/lib/bootstrap/sass/rails/engine.rb
@@ -1,8 +1,14 @@
+require File.dirname(__FILE__) + '/../../../twitter/bootstrap/twitter-bootstrap-breadcrumbs.rb'
+
+
 module Bootstrap
   module Sass
     module Rails
       class Engine < ::Rails::Engine
         # Make rails look at the vendored assets
+        initializer 'twitter-bootstrap-rails.setup_helpers' do |app|
+          ActionController::Base.send :include, Twitter::Bootstrap::BreadCrumbs
+        end
       end
     end
   end

--- a/lib/twitter/bootstrap/twitter-bootstrap-breadcrumbs.rb
+++ b/lib/twitter/bootstrap/twitter-bootstrap-breadcrumbs.rb
@@ -1,0 +1,42 @@
+module Twitter
+  module Bootstrap
+    module BreadCrumbs
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def add_breadcrumb(name, url, options = {})
+          class_name = self.name
+          before_filter options do |controller|
+            name = controller.send :translate_breadcrumb, name, class_name if name.is_a?(Symbol)
+            controller.send :add_breadcrumb, name, url
+          end
+        end
+      end
+
+      protected
+
+      def add_breadcrumb(name, url = '', options = {})
+        @breadcrumbs ||= []
+        name = translate_breadcrumb(name, self.class.name) if name.is_a?(Symbol)
+        url = eval(url.to_s) if url =~ /_path|_url|@/
+          @breadcrumbs << {:name => name, :url => url, :options => options}
+      end
+
+      def translate_breadcrumb(name, class_name)
+        scope = [:breadcrumbs]
+        namespace = class_name.underscore.split('/')
+        namespace.last.sub!('_controller', '')
+        scope += namespace
+
+        I18n.t name, :scope => scope
+      end
+
+      def render_breadcrumbs(divider = '/')
+        s = render :partial => 'twitter-bootstrap/breadcrumbs', :locals => {:divider => divider}
+        s.first
+      end
+    end
+  end
+end


### PR DESCRIPTION
[twitter-bootstrap-rails](https://github.com/seyhunak/twitter-bootstrap-rails) gem has useful helpers for ui components. here I added breadcrumbs helper from there. it is useful for me.

I really like idea of having twitter bootstrap written in sass. Thank you for your work.
