### PR TITLE
'img-retina' mixin variables not properly expanded

### DIFF
--- a/app/assets/stylesheets/twitter/bootstrap/_mixins.scss
+++ b/app/assets/stylesheets/twitter/bootstrap/_mixins.scss
@@ -318,7 +318,7 @@
 // Short retina mixin for setting background-image and -size
 
 @mixin img-retina($file-1x, $file-2x, $width-1x, $height-1x) {
-  background-image: image-url("$file-1x");
+  background-image: image-url($file-1x);
 
   @media
   only screen and (-webkit-min-device-pixel-ratio: 2),
@@ -327,7 +327,7 @@
   only screen and (        min-device-pixel-ratio: 2),
   only screen and (                min-resolution: 192dpi),
   only screen and (                min-resolution: 2dppx) {
-    background-image: image-url("$file-2x");
+    background-image: image-url($file-2x);
     background-size: $width-1x $height-1x;
   }
 }


### PR DESCRIPTION
Fixed issue in 'img-retina' mixin where 'file-1x' and 'file-2x' variables weren't being properly expanded due to enclosing quotes.
